### PR TITLE
feat(chart): upgrade app api to v1 for k8s 1.16

### DIFF
--- a/helm/basex-validator/Chart.yaml
+++ b/helm/basex-validator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: latest
 description: BaseX Validator for validating XML against eLife's schematron
 name: basex-validator
-version: 0.1.0
+version: 0.2.0

--- a/helm/basex-validator/templates/deployment.yaml
+++ b/helm/basex-validator/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}


### PR DESCRIPTION
Required to make chart compatible with k8s 1.16.

See also https://github.com/libero/reviewer/issues/1176